### PR TITLE
Modified default field length for google2fa_secret and User model is loaded according to Laravel configuration

### DIFF
--- a/database/migrations/2017_10_31_000001_add_google2fa_secret_to_users.php
+++ b/database/migrations/2017_10_31_000001_add_google2fa_secret_to_users.php
@@ -14,7 +14,7 @@ class AddGoogle2faSecretToUsers extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('google2fa_secret')->nullable();
+            $table->string('google2fa_secret', 255)->nullable();
         });
     }
 

--- a/src/Http/Requests/ValidateSecretRequest.php
+++ b/src/Http/Requests/ValidateSecretRequest.php
@@ -56,7 +56,8 @@ class ValidateSecretRequest extends FormRequest
     public function authorize()
     {
         try {
-            $this->user = User::findOrFail(session('2fa:user:id'));
+            $user_class = config('auth.providers.users.model');
+            $this->user = (new $user_class())->findOrFail(session('2fa:user:id'));
         } catch (Exception $exc) {
             return false;
         }


### PR DESCRIPTION
I implemented to small features that can improve the library compatibility:

1. I defined the google2fa_secret string length to 255:
 
The reason for that is because some laravel solutions had defined less than 255 char as length for different reasons like the usage of a different RDMS that doesn't support string index higher than 191 characters (See [old MariaDB version issue](https://laravel-news.com/laravel-5-4-key-too-long-error)). 

2. The "ValidateSecretRequest" is taken the User model from the default namespace \App\User, however some Laravel solutions are using a different User namespace, so I implemented a way to pick instantiate the User class using the Laravel's Auth configuration.   